### PR TITLE
Skip patients without PPF instead of aborting the whole cohort

### DIFF
--- a/src/ai_cdss/interface/recommender.py
+++ b/src/ai_cdss/interface/recommender.py
@@ -155,7 +155,8 @@ class CDSSInterface:
                 logger.info("No patients to process. Context: %s | Result: %s", context, payload)
                 return payload
 
-            rgs_data, protocol_similarity = self.data_service.prepare(patient_list=patient_ids)
+            valid_ids, rgs_data, protocol_similarity = self.data_service.prepare(patient_list=patient_ids)
+            skipped_ids = [p for p in patient_ids if p not in set(valid_ids)]
             scores = self.processor.process_data(rgs_data, scoring_date or pd.Timestamp.today())
             cdss = CDSS(scoring=scores, n=n, days=days, protocols_per_day=protocols_per_day)
 
@@ -167,8 +168,18 @@ class CDSSInterface:
             success_count = 0
             fail_count = 0
 
+            # Patients excluded upstream (e.g. missing PPF) are surfaced but do not
+            # count as failures — the run still succeeds for everyone with data.
+            for p in skipped_ids:
+                patient_results.append({
+                    "patient_id": p,
+                    "num_recommendations": 0,
+                    "status": "skipped",
+                    "skipped_reason": "missing_ppf",
+                })
+
             # --------- Per-patient Processing --------
-            for p in patient_ids:
+            for p in valid_ids:
                 result = self._process_patient(
                     patient=p,
                     cdss=cdss,
@@ -198,7 +209,8 @@ class CDSSInterface:
             payload = {
                 "status": top_status,
                 "run_id": str(unique_id),
-                "patients_processed": len(patient_ids),
+                "patients_processed": len(valid_ids),
+                "patients_skipped": len(skipped_ids),
                 "total_recommendations": total_recommendations,
                 "per_patient": patient_results,
                 "start_time": datetime_now.isoformat(),

--- a/src/ai_cdss/services/data_preparation.py
+++ b/src/ai_cdss/services/data_preparation.py
@@ -6,7 +6,7 @@ import pandas as pd
 from ai_cdss.loaders import DataLoader
 from ai_cdss.models import DataUnitSet
 from ai_cdss.services.whitelist_service import ProtocolWhitelistService
-from ai_cdss.constants import PROTOCOL_WHITELIST_YAML, PROTOCOL_ID, PROTOCOL_A, PROTOCOL_B
+from ai_cdss.constants import PROTOCOL_WHITELIST_YAML, PROTOCOL_ID, PROTOCOL_A, PROTOCOL_B, PATIENT_ID
 
 logger = logging.getLogger(__name__)
 
@@ -30,26 +30,39 @@ class RecommendationDataService:
         Prepare and return all data required for recommendations for a study.
         Handles missing PPF computation as needed.
 
+        Patients without PPF are excluded (with a warning) rather than aborting
+        the whole cohort: one missing PPF must not starve recommendations for
+        every other patient in the run. Only raises if *no* patient has PPF.
+
         Args:
             patient_list (List[int]): List of patient identifiers.
 
         Returns:
             Tuple containing:
-                - patient_list (List[int])
+                - valid_patients (List[int]): patients that had PPF and will be processed
                 - rgs_data (DataUnitSet): Contains session and ppf DataUnits
                 - protocol_similarity (object)
         """
         ppf = self.loader.load_ppf_data(patient_list)
-        missing = ppf.metadata.get("missing_patients", [])
+        missing = set(ppf.metadata.get("missing_patients", []))
+        valid_patients = [p for p in patient_list if p not in missing]
         if missing:
-            raise RuntimeError(
-                f"PPF data missing for patients: {missing}. Please compute PPF before proceeding."
+            logger.warning(
+                "Skipping %d patient(s) with missing PPF: %s. Proceeding for %d patient(s): %s",
+                len(missing), sorted(missing), len(valid_patients), valid_patients,
             )
-        session = self.loader.load_session_data(patient_list)
-        patient_data = self.loader.load_patient_data(patient_list)
+        if not valid_patients:
+            raise RuntimeError(
+                f"PPF data missing for all requested patients: {sorted(missing)}. "
+                "Please compute PPF before proceeding."
+            )
+        # Drop placeholder PPF rows for the excluded patients before scoring.
+        ppf.data = ppf.data[ppf.data[PATIENT_ID].isin(valid_patients)]
+        session = self.loader.load_session_data(valid_patients)
+        patient_data = self.loader.load_patient_data(valid_patients)
         protocol_similarity = self.loader.load_protocol_similarity()
 
-        logger.info("Loaded data for patients: %s", patient_list)
+        logger.info("Loaded data for patients: %s", valid_patients)
         logger.info("Session data shape: %s", session.data.shape)
         logger.info("PPF data shape: %s", ppf.data.shape)
 
@@ -75,5 +88,5 @@ class RecommendationDataService:
             ]
 
         rgs_data = DataUnitSet([session, patient_data, ppf])
-        return rgs_data, protocol_similarity
+        return valid_patients, rgs_data, protocol_similarity
     


### PR DESCRIPTION
## Problem

`RecommendationDataService.prepare()` loads PPF for the **entire study cohort in one call** and raises `RuntimeError` if *any single* patient is missing PPF — before a single patient is processed. So one un-computed patient (e.g. a newly enrolled one whose PPF hasn't been generated yet) aborts the whole run: `status: failure`, `per_patient: []`, `total_recommendations: 0`. Every other patient due that day is silently starved.

Observed in prod: a study run failed with `PPF data missing for patients: [5041]`, which blocked the current-week recommendation for an unrelated patient whose week boundary fell on that day, while patients already recommended earlier in the week kept their rows — making it look like one patient's missing PPF selectively hit another.

## Fix

`prepare()` now **excludes** missing-PPF patients (with a warning) and returns the valid patient list, instead of aborting. It only raises when *no* patient has PPF.

`_recommend_for_patients_core` consumes the valid list, loops over it (so `patient_dict[p]` stays safe), and surfaces excluded patients in `per_patient` as `status: "skipped"`, `skipped_reason: "missing_ppf"` — they do **not** count as failures. Adds `patients_skipped` to the payload.

## Behaviour

- Before: cohort `[A (has PPF), B (no PPF)]` → `failure`, 0 recommendations for everyone.
- After: `A` gets recommended normally; `B` reported as `skipped`; run `status: success`.

Verified locally against prod data: `[4994 (PPF), 99999999 (no PPF)]` → `status: success`, 4994 → 12 recs, bogus id → `skipped`.

## Scope

Two files. `prepare()` has a single caller (`_recommend_for_patients_core`); no tests reference the old return signature.
